### PR TITLE
feat: v3 transactions with bip340 schnorr

### DIFF
--- a/crypto/identity/private_key.py
+++ b/crypto/identity/private_key.py
@@ -10,17 +10,19 @@ class PrivateKey(object):
         self.private_key = PvtKey.from_hex(private_key)
         self.public_key = hexlify(self.private_key.public_key.format()).decode()
 
-    def sign(self, message):
+    def sign(self, message, nonce=None):
         """Sign a message with this private key object
 
         Args:
             message (bytes): bytes data you want to sign
+            nonce (int): deterministic nonce
 
         Returns:
             str: signature of the signed message
         """
-        signature = self.private_key.sign(message)
-        return hexlify(signature).decode()
+        from crypto.utils.crypto import sign_schnorr  # circular imports
+        signature = sign_schnorr(message, self.private_key, nonce)
+        return signature
 
     def to_hex(self):
         """Returns a private key in hex format

--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -196,14 +196,16 @@ class Transaction(object):
 
         msg = self.to_bytes(True, True, True)
 
-        public_key_indexes = {}
+        public_key_indexes = []
         verified = False
         verified_signatures = 0
 
         for signature in signatures:
             public_key_index = int(signature[0:2], 16)
-            if public_key_index in public_key_indexes.keys():
+            if public_key_index in public_key_indexes:
                 raise SolarInvalidTransaction('Transaction could not be verified')
+            else:
+                public_key_indexes.append(public_key_index)
             
             partial_signature = signature[2:130]
             public_key = public_keys[public_key_index]

--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -14,6 +14,7 @@ from crypto.exceptions import SolarInvalidTransaction
 from crypto.schnorr import schnorr
 from crypto.transactions.deserializer import Deserializer
 from crypto.transactions.serializer import Serializer
+from crypto.utils.crypto import verify_schnorr, verify_schnorr_legacy
 
 TRANSACTION_ATTRIBUTES = {
     'amount': 0,
@@ -157,10 +158,10 @@ class Transaction(object):
 
         if self.version > 2:
             # schnorr bip340
-            is_valid = ssa.verify(msg, self.senderPublicKey, self.signature)
+            is_valid = verify_schnorr(msg, self.senderPublicKey, self.signature)
         else:
             # schnorr legacy
-            is_valid = schnorr.b410_schnorr_verify(msg, self.senderPublicKey, self.signature)
+            is_valid = verify_schnorr_legacy(msg, self.senderPublicKey, self.signature)
 
         if not is_valid:
             raise SolarInvalidTransaction('Transaction could not be verified')
@@ -172,10 +173,10 @@ class Transaction(object):
 
         if self.version > 2:
             # schnorr bip340
-            is_valid = ssa.verify(msg, secondPublicKey, self.signSignature)
+            is_valid = verify_schnorr(msg, secondPublicKey, self.signSignature)
         else:
             # schnorr legacy
-            is_valid = schnorr.b410_schnorr_verify(msg, secondPublicKey, self.signSignature)
+            is_valid = verify_schnorr_legacy(msg, secondPublicKey, self.signSignature)
 
         if not is_valid:
             raise SolarInvalidTransaction('Transaction could not be verified')
@@ -209,10 +210,10 @@ class Transaction(object):
             if self.version > 2:
                 # schnorr bip340
                 msg_hash = msg
-                is_valid = ssa.verify(msg_hash, public_key, partial_signature)
+                is_valid = verify_schnorr(msg_hash, public_key, partial_signature)
             else:
                 # schnorr legacy
-                is_valid = schnorr.b410_schnorr_verify(msg, public_key, partial_signature)
+                is_valid = verify_schnorr_legacy(msg, public_key, partial_signature)
 
             if is_valid:
                 verified_signatures += 1

--- a/crypto/utils/crypto.py
+++ b/crypto/utils/crypto.py
@@ -6,21 +6,61 @@ from crypto.schnorr import schnorr
 from crypto.identity.private_key import PrivateKey
 
 
-def sign_schnorr(msg: str, private_key: PrivateKey, nonce: int = None) -> str:
+def sign_schnorr(msg: bytes, private_key: PrivateKey, nonce: int = None) -> str:
+    """Signs a message using Schnorr BIP340
+
+    Args:
+        msg (bytes): a message you wish to sign
+        private_key (PrivateKey): private key object
+        nonce (int): deterministic nonce
+
+    Returns:
+        str: returnes a hex string of a signature
+    """
     signature = ssa.sign(msg, private_key.to_hex(), nonce)
     return signature.serialize().hex()
 
 
-def sign_schnorr_legacy(msg: str, private_key: PrivateKey) -> str:
+def sign_schnorr_legacy(msg: bytes, private_key: PrivateKey) -> str:
+    """Signs a message using Legacy Schnorr
+
+    Args:
+        msg (bytes): a message you wish to sign
+        private_key (PrivateKey): private key object
+        nonce (int): deterministic nonce
+
+    Returns:
+        str: returnes a hex string of a signature
+    """
     msg = hashlib.sha256(msg).digest()
     secret = unhexlify(private_key.to_hex())
     signature = schnorr.bcrypto410_sign(msg, secret).hex()
     return signature
 
 
-def verify_schnorr(msg: str, sender_public_key: str, signature: str) -> bool:
-    return ssa.verify(msg, sender_public_key, signature)
+def verify_schnorr(msg: bytes, public_key: str, signature: str) -> bool:
+    """Verifies a message using Schnorr BIP340
+
+    Args:
+        msg (bytes): a message you wish to sign
+        public_key (str)
+        signature (str)
+
+    Returns:
+        bool
+    """
+    return ssa.verify(msg, public_key, signature)
 
 
-def verify_schnorr_legacy(msg: str, sender_public_key: str, signature: str) -> bool:
-    return schnorr.b410_schnorr_verify(msg, sender_public_key, signature)
+def verify_schnorr_legacy(msg: bytes, public_key: str, signature: str) -> bool:
+    """Verifies a message using Legacy Schnorr
+
+    Args:
+        msg (bytes): a message you wish to sign
+        public_key (str)
+        signature (str)
+
+    Returns:
+        bool
+    """
+    return schnorr.b410_schnorr_verify(msg, public_key, signature)

--- a/crypto/utils/crypto.py
+++ b/crypto/utils/crypto.py
@@ -1,0 +1,26 @@
+import hashlib
+from binascii import unhexlify
+from btclib.ecc import ssa
+
+from crypto.schnorr import schnorr
+from crypto.identity.private_key import PrivateKey
+
+
+def sign_schnorr(msg: str, private_key: PrivateKey, nonce: int = None) -> str:
+    signature = ssa.sign(msg, private_key.to_hex(), nonce)
+    return signature.serialize().hex()
+
+
+def sign_schnorr_legacy(msg: str, private_key: PrivateKey) -> str:
+    msg = hashlib.sha256(msg).digest()
+    secret = unhexlify(private_key.to_hex())
+    signature = schnorr.bcrypto410_sign(msg, secret).hex()
+    return signature
+
+
+def verify_schnorr(msg: str, sender_public_key: str, signature: str) -> bool:
+    return ssa.verify(msg, sender_public_key, signature)
+
+
+def verify_schnorr_legacy(msg: str, sender_public_key: str, signature: str) -> bool:
+    return schnorr.b410_schnorr_verify(msg, sender_public_key, signature)

--- a/crypto/utils/message.py
+++ b/crypto/utils/message.py
@@ -14,20 +14,19 @@ class Message(object):
                 raise TypeError('Invalid keyword argument %s' % k)
 
     @classmethod
-    def sign(cls, message, passphrase, nonce=None):
+    def sign(cls, message, passphrase):
         """Signs a message
 
         Args:
             message (str/bytes): a message you wish to sign
             passphrase (str): passphrase you wish to use to sign the message
-            nonce (int): deterministic nonce
 
         Returns:
             Message: returns a message object
         """
         message_bytes = message if isinstance(message, bytes) else message.encode()
         private_key = PrivateKey.from_passphrase(passphrase)
-        signature = sign_schnorr(message_bytes, private_key, nonce)
+        signature = sign_schnorr(message_bytes, private_key)
         return cls(message=message, signature=signature, publicKey=private_key.public_key)
 
     def verify(self):

--- a/crypto/utils/message.py
+++ b/crypto/utils/message.py
@@ -1,8 +1,8 @@
 import json
-from binascii import unhexlify
+from btclib.ecc import ssa
 
 from crypto.identity.private_key import PrivateKey
-from crypto.identity.public_key import PublicKey
+from crypto.utils.crypto import sign_schnorr, verify_schnorr
 
 
 class Message(object):
@@ -14,20 +14,20 @@ class Message(object):
                 raise TypeError('Invalid keyword argument %s' % k)
 
     @classmethod
-    def sign(cls, message, passphrase):
+    def sign(cls, message, passphrase, nonce=None):
         """Signs a message
 
         Args:
             message (str/bytes): a message you wish to sign
-            passphrase (str/byes): passphrase you wish to use to sign the message
+            passphrase (str): passphrase you wish to use to sign the message
+            nonce (int): deterministic nonce
 
         Returns:
             Message: returns a message object
         """
         message_bytes = message if isinstance(message, bytes) else message.encode()
-        passphrase = passphrase.decode() if isinstance(passphrase, bytes) else passphrase
         private_key = PrivateKey.from_passphrase(passphrase)
-        signature = private_key.sign(message_bytes)
+        signature = sign_schnorr(message_bytes, private_key, nonce)
         return cls(message=message, signature=signature, publicKey=private_key.public_key)
 
     def verify(self):
@@ -37,9 +37,8 @@ class Message(object):
             bool: returns a boolean - true if verified, false if not
         """
         message = self.message if isinstance(self.message, bytes) else self.message.encode()
-        key = PublicKey.from_hex(self.publickey) if hasattr(self, 'publickey') else PublicKey.from_hex(self.publicKey)
-        signature = unhexlify(self.signature)
-        is_verified = key.public_key.verify(signature, message)
+        public_key = self.publickey if hasattr(self, 'publickey') else self.publicKey
+        is_verified = verify_schnorr(message, public_key, self.signature)
         return is_verified
 
     def to_dict(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ import setuptools
 requires = [
     'base58',
     'binary-helpers',
-    'coincurve'
+    'coincurve',
+    'btclib'
 ]
 
 tests_require = [
@@ -15,7 +16,7 @@ tests_require = [
     'flake8-print>=3.1.0',
     'flake8-quotes>=1.0.0',
     'pytest>=3.6.1',
-    'pytest-cov>=2.5.1'
+    'pytest-cov>=2.5.1',
 ]
 
 extras_require = {
@@ -28,7 +29,7 @@ setup_requires = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys
 setuptools.setup(
     name='solarnetwork-crypto',
     description='A simple Cryptography Implementation in Python for the Solar Blockchain.',
-    version='2.0.0',
+    version='3.0.0',
     author='Solar-Network',
     author_email='hello@solar.org',
     url='https://github.com/Solar-network/python-crypto',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,13 +311,13 @@ def message():
     data = {
         'camelCase_pk': {
             'publicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-            'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
+            'signature': '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798f9ee8f2b718dc55e840f906c5071f63694ddeb35af8858f2a54cfdb3bd36fce1',  # noqa
             'message': 'Hello World'
         },
 
         'snake_case_pk': {
           'publickey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-          'signature': '304402200fb4adddd1f1d652b544ea6ab62828a0a65b712ed447e2538db0caebfa68929e02205ecb2e1c63b29879c2ecf1255db506d671c8b3fa6017f67cfd1bf07e6edd1cc8',  # noqa
+          'signature': '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798f9ee8f2b718dc55e840f906c5071f63694ddeb35af8858f2a54cfdb3bd36fce1',  # noqa
           'message': 'Hello World'
         },
         'passphrase': 'this is a top secret passphrase'

--- a/tests/transactions/builder/test_delegate_registration.py
+++ b/tests/transactions/builder/test_delegate_registration.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_DELEGATE_REGISTRATION, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,7 +8,8 @@ from crypto.transactions.builder.delegate_registration import DelegateRegistrati
 set_network(Testnet)
 
 
-def test_delegate_registration_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_delegate_registration_transaction(version):
     """Test if a delegate registration transaction gets built
     """
     delegate_name = 'mr.delegate'
@@ -14,21 +17,22 @@ def test_delegate_registration_transaction():
     transaction = DelegateRegistration(delegate_name)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['asset']['delegate']['username'] == delegate_name
     assert transaction_dict['type'] is TRANSACTION_DELEGATE_REGISTRATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 2500000000
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_delegate_registration_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_delegate_registration_transaction_custom_fee(version):
     """Test if a delegate registration transaction gets built with a custom fee
     """
     delegate_name = 'mr.delegate'
@@ -36,15 +40,15 @@ def test_delegate_registration_transaction_custom_fee():
     transaction = DelegateRegistration(delegate_name, 5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['asset']['delegate']['username'] == delegate_name
     assert transaction_dict['type'] is TRANSACTION_DELEGATE_REGISTRATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_delegate_resignation.py
+++ b/tests/transactions/builder/test_delegate_resignation.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_DELEGATE_RESIGNATION, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,39 +8,41 @@ from crypto.transactions.builder.delegate_resignation import DelegateResignation
 set_network(Testnet)
 
 
-def test_delegate_resignation_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_delegate_resignation_transaction(version):
     """Test if delegate resignation transaction gets built
     """
     transaction = DelegateResignation()
     transaction.set_nonce(1)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_DELEGATE_RESIGNATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 2500000000
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_delegate_resignation_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_delegate_resignation_transaction_custom_fee(version):
     """Test if delegate resignation transaction gets built with a custom fee
     """
     transaction = DelegateResignation(5)
     transaction.set_nonce(1)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_DELEGATE_RESIGNATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_htlc_lock.py
+++ b/tests/transactions/builder/test_htlc_lock.py
@@ -51,7 +51,8 @@ def test_htlc_lock_transation_amount_negative():
         )
 
 
-def test_htlc_lock_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_htlc_lock_transaction(version):
     """Test if timelock transaction gets built
     """
     secret_hash = _generate_secret_hash()
@@ -65,7 +66,8 @@ def test_htlc_lock_transaction():
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['recipientId'] == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
@@ -73,17 +75,17 @@ def test_htlc_lock_transaction():
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_HTLC_LOCK
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 10000000
     assert transaction_dict['asset']['lock']['secretHash'] == secret_hash
     assert transaction_dict['asset']['lock']['expiration']['type'] == 1
     assert transaction_dict['asset']['lock']['expiration']['value'] == 1573455822
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_htlc_lock_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_htlc_lock_transaction_custom_fee(version):
     """Test if timelock transaction gets built with a custom fee
     """
     secret_hash = _generate_secret_hash()
@@ -98,7 +100,8 @@ def test_htlc_lock_transaction_custom_fee():
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['recipientId'] == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
@@ -106,14 +109,13 @@ def test_htlc_lock_transaction_custom_fee():
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_HTLC_LOCK
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
     assert transaction_dict['asset']['lock']['secretHash'] == secret_hash
     assert transaction_dict['asset']['lock']['expiration']['type'] == 1
     assert transaction_dict['asset']['lock']['expiration']['value'] == 1573455822
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
 def _generate_secret_hash():

--- a/tests/transactions/builder/test_htlc_refund.py
+++ b/tests/transactions/builder/test_htlc_refund.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_HTLC_REFUND, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,7 +8,8 @@ from crypto.transactions.builder.htlc_refund import HtlcRefund
 set_network(Testnet)
 
 
-def test_timelock_refund_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_timelock_refund_transaction(version):
     """Test if timelock transaction gets built
     """
     transaction = HtlcRefund(
@@ -15,21 +18,22 @@ def test_timelock_refund_transaction():
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_HTLC_REFUND
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 0
     assert transaction_dict['asset']['refund']['lockTransactionId'] == '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4'
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_timelock_refund_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_timelock_refund_transaction_custom_fee(version):
     """Test if timelock transaction gets built with custom fee
     """
     transaction = HtlcRefund(
@@ -39,15 +43,15 @@ def test_timelock_refund_transaction_custom_fee():
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_HTLC_REFUND
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
     assert transaction_dict['asset']['refund']['lockTransactionId'] == '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4'
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_ipfs.py
+++ b/tests/transactions/builder/test_ipfs.py
@@ -1,3 +1,4 @@
+import pytest
 from base58 import b58encode
 
 from crypto.configuration.network import set_network
@@ -8,7 +9,8 @@ from crypto.transactions.builder.ipfs import IPFS
 set_network(Testnet)
 
 
-def test_ipfs_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_ipfs_transaction(version):
     """Test if ipfs transaction gets built
     """
     ipfs_id = b58encode('hello')
@@ -16,21 +18,22 @@ def test_ipfs_transaction():
     transaction = IPFS(ipfs_id)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_IPFS
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 500000000
     assert transaction_dict['asset']['ipfs'] == ipfs_id
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_ipfs_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_ipfs_transaction_custom_fee(version):
     """Test if ipfs transaction gets built with custom fee
     """
     ipfs_id = b58encode('hello')
@@ -38,15 +41,15 @@ def test_ipfs_transaction_custom_fee():
     transaction = IPFS(ipfs_id, 5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_IPFS
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
     assert transaction_dict['asset']['ipfs'] == ipfs_id
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_multi_payment.py
+++ b/tests/transactions/builder/test_multi_payment.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_MULTI_PAYMENT, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,7 +8,8 @@ from crypto.transactions.builder.multi_payment import MultiPayment
 set_network(Testnet)
 
 
-def test_multi_payment_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_multi_payment_transaction(version):
     """Test if multi payment transaction gets built
     """
     transaction = MultiPayment()
@@ -14,13 +17,13 @@ def test_multi_payment_transaction():
     transaction.set_nonce(1)
     transaction.add_payment(1, 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri')
     transaction.add_payment(2, 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej')
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_MULTI_PAYMENT
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 10000000
     assert transaction_dict['asset']['payments'][0]['amount'] == 1
@@ -28,24 +31,25 @@ def test_multi_payment_transaction():
     assert transaction_dict['asset']['payments'][1]['amount'] == 2
     assert transaction_dict['asset']['payments'][1]['recipientId'] == 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej'
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_multi_payment_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_multi_payment_transaction_custom_fee(version):
     """Test if multi payment transaction gets built with a custom fee
     """
     transaction = MultiPayment(fee=5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
+    transaction.set_version(version)
     transaction.add_payment(1, 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri')
     transaction.add_payment(2, 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej')
-    transaction.schnorr_sign('testing')
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_MULTI_PAYMENT
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
     assert transaction_dict['asset']['payments'][0]['amount'] == 1
@@ -53,4 +57,4 @@ def test_multi_payment_transaction_custom_fee():
     assert transaction_dict['asset']['payments'][1]['amount'] == 2
     assert transaction_dict['asset']['payments'][1]['recipientId'] == 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej'
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_multi_signature_registration.py
+++ b/tests/transactions/builder/test_multi_signature_registration.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_MULTI_SIGNATURE_REGISTRATION, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,7 +8,8 @@ from crypto.transactions.builder.multi_signature_registration import MultiSignat
 set_network(Testnet)
 
 
-def test_multi_signature_registration_transaction():
+@pytest.mark.parametrize("version", [3])
+def test_multi_signature_registration_transaction(version):
     """Test if a second signature registration transaction gets built
     """
     publicKeys = [
@@ -20,21 +23,21 @@ def test_multi_signature_registration_transaction():
     transaction.set_nonce(1)
     transaction.set_min(2)
     transaction.set_public_keys(publicKeys)
+    transaction.set_version(version)
     transaction.add_participant('03860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f')
     transaction.multi_sign('this is a top secret passphrase 1', 0)
     transaction.multi_sign('this is a top secret passphrase 2', 1)
     transaction.multi_sign('this is a top secret passphrase 3', 2)
 
-    transaction.schnorr_sign('this is a top secret passphrase 1')
+    transaction.sign('this is a top secret passphrase 1')
 
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
-    assert transaction_dict['version'] == 2
+    assert transaction_dict['version'] == version
     assert transaction_dict['fee'] == 2000000000
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_MULTI_SIGNATURE_REGISTRATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['asset']['multiSignature']['min'] == 2
 
@@ -42,4 +45,4 @@ def test_multi_signature_registration_transaction():
     assert transaction_dict['asset']['multiSignature']['publicKeys'][1] == publicKeys[1]
     assert transaction_dict['asset']['multiSignature']['publicKeys'][2] == '03860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f'
 
-    transaction.schnorr_verify_multisig()  # if no exception is raised, it means the transaction is valid
+    assert transaction.verify_multisig(transaction_dict['asset']['multiSignature'])  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_multi_signature_registration.py
+++ b/tests/transactions/builder/test_multi_signature_registration.py
@@ -8,9 +8,9 @@ from crypto.transactions.builder.multi_signature_registration import MultiSignat
 set_network(Testnet)
 
 
-@pytest.mark.parametrize("version", [3])
+@pytest.mark.parametrize("version", [2, 3])
 def test_multi_signature_registration_transaction(version):
-    """Test if a second signature registration transaction gets built
+    """Test if a multi signature registration transaction gets built
     """
     publicKeys = [
         '0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896',
@@ -45,4 +45,4 @@ def test_multi_signature_registration_transaction(version):
     assert transaction_dict['asset']['multiSignature']['publicKeys'][1] == publicKeys[1]
     assert transaction_dict['asset']['multiSignature']['publicKeys'][2] == '03860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f'
 
-    assert transaction.verify_multisig(transaction_dict['asset']['multiSignature'])  # if no exception is raised, it means the transaction is valid
+    assert transaction.verify_multisig(transaction_dict['asset']['multiSignature'])

--- a/tests/transactions/builder/test_second_signature_registration.py
+++ b/tests/transactions/builder/test_second_signature_registration.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_SECOND_SIGNATURE_REGISTRATION, TRANSACTION_TYPE_GROUP
 from crypto.networks.testnet import Testnet
@@ -6,39 +8,41 @@ from crypto.transactions.builder.second_signature_registration import SecondSign
 set_network(Testnet)
 
 
-def test_second_signature_registration_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_second_signature_registration_transaction(version):
     """Test if a second signature registration transaction gets built
     """
     transaction = SecondSignatureRegistration('this is a top secret passphrase')
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_SECOND_SIGNATURE_REGISTRATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 500000000
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_second_signature_registration_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_second_signature_registration_transaction_custom_fee(version):
     """Test if a second signature registration transaction gets built with a custom fee
     """
     transaction = SecondSignatureRegistration('this is a top secret passphrase', 5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_SECOND_SIGNATURE_REGISTRATION
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_transfer.py
+++ b/tests/transactions/builder/test_transfer.py
@@ -10,7 +10,8 @@ from crypto.transactions.builder.transfer import Transfer
 set_network(Testnet)
 
 
-def test_transfer_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_transfer_transaction(version):
     """Test if a transfer transaction gets built
     """
     transaction = Transfer(
@@ -19,20 +20,22 @@ def test_transfer_transaction():
     )
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('this is a top secret passphrase')
+    transaction.set_version(version)
+    transaction.sign('this is a top secret passphrase')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
+    assert transaction_dict['version'] == version
     assert transaction_dict['type'] is TRANSACTION_TRANSFER
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 10000000
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_transfer_transaction_update_amount():
+@pytest.mark.parametrize("version", [2, 3])
+def test_transfer_transaction_update_amount(version):
     """Test if a transfer transaction can update an amount
     """
     transaction = Transfer(
@@ -42,20 +45,22 @@ def test_transfer_transaction_update_amount():
     transaction.set_amount(10)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('this is a top secret passphrase')
+    transaction.set_version(version)
+    transaction.sign('this is a top secret passphrase')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
+    assert transaction_dict['version'] == version
     assert transaction_dict['type'] is TRANSACTION_TRANSFER
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['amount'] == 10
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_transfer_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_transfer_transaction_custom_fee(version):
     """Test if a transfer transaction gets built with a custom fee
     """
     transaction = Transfer(
@@ -65,20 +70,21 @@ def test_transfer_transaction_custom_fee():
     )
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('this is a top secret passphrase')
+    transaction.set_version(version)
+    transaction.sign('this is a top secret passphrase')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['type'] is TRANSACTION_TRANSFER
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_transfer_secondsig_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_transfer_secondsig_transaction(version):
     """Test if a transfer transaction with second signature gets built
     """
     transaction = Transfer(
@@ -87,7 +93,8 @@ def test_transfer_secondsig_transaction():
     )
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('this is a top secret passphrase')
+    transaction.set_version(version)
+    transaction.sign('this is a top secret passphrase')
     transaction.second_sign('second top secret passphrase')
     transaction_dict = transaction.to_dict()
 
@@ -95,11 +102,10 @@ def test_transfer_secondsig_transaction():
     assert transaction_dict['signature']
     assert transaction_dict['signSignature']
     assert transaction_dict['type'] is TRANSACTION_TRANSFER
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
-    transaction.schnorr_verify_second(PublicKey.from_passphrase('second top secret passphrase'))  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify_second(PublicKey.from_passphrase('second top secret passphrase'))  # if no exception is raised, it means the transaction is valid
 
 
 def test_parse_signatures(transaction_type_0):

--- a/tests/transactions/builder/test_vote.py
+++ b/tests/transactions/builder/test_vote.py
@@ -1,3 +1,5 @@
+import pytest
+
 from crypto.configuration.network import set_network
 from crypto.constants import TRANSACTION_TYPE_GROUP, TRANSACTION_VOTE
 from crypto.networks.testnet import Testnet
@@ -6,7 +8,8 @@ from crypto.transactions.builder.vote import Vote
 set_network(Testnet)
 
 
-def test_vote_transaction():
+@pytest.mark.parametrize("version", [2, 3])
+def test_vote_transaction(version):
     """Test if a vote transaction gets built
     """
     vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
@@ -14,21 +17,22 @@ def test_vote_transaction():
     transaction = Vote(vote)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['asset']['votes']
     assert transaction_dict['type'] is TRANSACTION_VOTE
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 100000000
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
 
 
-def test_vote_transaction_custom_fee():
+@pytest.mark.parametrize("version", [2, 3])
+def test_vote_transaction_custom_fee(version):
     """Test if a vote transaction gets built with a custom fee
     """
     vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
@@ -36,15 +40,15 @@ def test_vote_transaction_custom_fee():
     transaction = Vote(vote, 5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.schnorr_sign('testing')
+    transaction.set_version(version)
+    transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
     assert transaction_dict['asset']['votes']
     assert transaction_dict['type'] is TRANSACTION_VOTE
-    assert transaction_dict['typeGroup'] == 1
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
 
-    transaction.schnorr_verify()  # if no exception is raised, it means the transaction is valid
+    transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/deserializers/test_burn.py
+++ b/tests/transactions/deserializers/test_burn.py
@@ -18,4 +18,4 @@ def test_vote_deserializer(transaction_type_burn):
     assert actual.id == '7e1dfa5cc0f70155530438d271885d39370fa0143287e8f6d40d2e67b9b6e366'
     assert actual.signature == 'ef071aa1c7631a6ace4227f583c78d922e938a1c3a8997a959e834e6b43ece34313a68dcf56ac606fb387006d9cbc962249376326c9dd84b81979eed5d1163d8'
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_delegate_registration.py
+++ b/tests/transactions/deserializers/test_delegate_registration.py
@@ -19,4 +19,4 @@ def test_delegate_registration_deserializer():
     assert actual.amount == 0
     assert actual.id == 'cfd113d8cd9fd46b07030c14fac38c1d3fc0eca991e999eab9d0152ea96ab0dc'
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_delegate_resignation.py
+++ b/tests/transactions/deserializers/test_delegate_resignation.py
@@ -18,4 +18,4 @@ def test_delegate_resignation_deserializer():
     assert actual.amount == 0
     assert actual.id == '707b4deb339e717dfef44c40db0692015ce9bbab015c007b016b8a46b341e859'
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_htlc_claim.py
+++ b/tests/transactions/deserializers/test_htlc_claim.py
@@ -20,4 +20,4 @@ def test_htlc_claim_deserializer():
     assert actual.asset['claim']['lockTransactionId'] == '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4'  # noqa
     assert actual.asset['claim']['unlockSecret'] == '6434323233626639336532303235303561366135303134323161383864396661'  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_htlc_lock.py
+++ b/tests/transactions/deserializers/test_htlc_lock.py
@@ -22,4 +22,4 @@ def test_htlc_lock_deserializer():
     assert actual.asset['lock']['expiration']['type'] == 1  # noqa
     assert actual.asset['lock']['expiration']['value'] == 1573455822  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_htlc_refund.py
+++ b/tests/transactions/deserializers/test_htlc_refund.py
@@ -19,4 +19,4 @@ def test_htlc_refund_deserializer():
     assert actual.id == '9356aa730990a2ea8e9871ffa65800f34ef1a4bec3215d89c950e72d82a34e91'
     assert actual.asset['refund']['lockTransactionId'] == '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4'  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_ipfs.py
+++ b/tests/transactions/deserializers/test_ipfs.py
@@ -19,4 +19,4 @@ def test_ipfs_deserializer():
     assert actual.id == '818228ce634b46c488f3b2df8fd02bd50331ebdedb44df5b9b11b97b01e9fb36'
     assert actual.asset['ipfs'] == 'QmR45FmbVVrixReBwJkhEKde2qwHYaQzGxu4ZoDeswuF9w'  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_multi_payment.py
+++ b/tests/transactions/deserializers/test_multi_payment.py
@@ -22,4 +22,4 @@ def test_multi_payment_deserializer():
     assert actual.asset['payments'][1]['amount'] == 2  # noqa
     assert actual.asset['payments'][1]['recipientId'] == 'AZFEPTWnn2Sn8wDZgCRF8ohwKkrmk2AZi1'  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_multi_signature_registration.py
+++ b/tests/transactions/deserializers/test_multi_signature_registration.py
@@ -29,4 +29,4 @@ def test_multi_signature_registration_deserializer():
         '02d0012f035dc3fd54173c83d40217914653488fe9ce592dca34234163181d255281f2be7033725cfc4a6786509e7fabbaf0be8cf50882fc7b66fe94f259fd004e'  # noqa
     ]
 
-    actual.verify_schnorr_multisig()
+    assert actual.verify_signatures(data['asset']['multiSignature'])

--- a/tests/transactions/deserializers/test_second_signature_registration.py
+++ b/tests/transactions/deserializers/test_second_signature_registration.py
@@ -19,4 +19,4 @@ def test_second_signature_registration_deserializer():
     assert actual.id == '173a3230159b45d772b2e0348f42af53913bf3e376397f29b8e0bda290badbe4'
     assert actual.asset['signature']['publicKey'] == '03699e966b2525f9088a6941d8d94f7869964a000efe65783d78ac82e1199fe609'  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_transfer.py
+++ b/tests/transactions/deserializers/test_transfer.py
@@ -21,7 +21,7 @@ def test_transfer_deserializer():
     assert actual.id == '129517023bd895b682bbb38b1d1f99e9222bd487899c843da22d8572b0fb52a8'
     assert actual.signature == '136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b'
 
-    actual.verify_schnorr()
+    actual.verify()
 
 
 @pytest.mark.skip()
@@ -45,4 +45,4 @@ def test_transfer_second_signature_deserializer():
     assert actual.signature == '136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b'
     assert actual.signSignature == '02dd94f611e300ad77147d808a34e942b379c5468760d8605adc0304400a2578a2039468b844f30ad1f0515f9cce33855791296117bfe8ef3caa664152644fd6'
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/transactions/deserializers/test_vote.py
+++ b/tests/transactions/deserializers/test_vote.py
@@ -20,4 +20,4 @@ def test_vote_deserializer():
 
     assert actual.asset['votes'] == ['+022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d']  # noqa
 
-    actual.verify_schnorr()
+    actual.verify()

--- a/tests/utils/test_message.py
+++ b/tests/utils/test_message.py
@@ -3,9 +3,18 @@ import json
 from crypto.utils.message import Message
 
 
-def test_signing(message):
-    result = Message.sign(message['camelCase_pk']['message'], message['passphrase'])
+def test_signing_deterministic(message):
+    result = Message.sign(message['camelCase_pk']['message'], message['passphrase'], 1)
     assert result.to_dict() == message['camelCase_pk']
+
+def test_signing_non_deterministic(message):
+    first = Message.sign(message['camelCase_pk']['message'], message['passphrase'])
+    assert first.verify() is True
+
+    second = Message.sign(message['camelCase_pk']['message'], message['passphrase'])
+    assert second.verify() is True
+
+    assert first.signature != second.signature
 
 
 def test_verify_with_publickey(message):

--- a/tests/utils/test_message.py
+++ b/tests/utils/test_message.py
@@ -3,10 +3,6 @@ import json
 from crypto.utils.message import Message
 
 
-def test_signing_deterministic(message):
-    result = Message.sign(message['camelCase_pk']['message'], message['passphrase'], 1)
-    assert result.to_dict() == message['camelCase_pk']
-
 def test_signing_non_deterministic(message):
     first = Message.sign(message['camelCase_pk']['message'], message['passphrase'])
     assert first.verify() is True


### PR DESCRIPTION
### Changes

- joined the schnorr legacy and bip340 schnorr under a unified signing and verifying functions so we dont have two separate functions
-  made V3 a default transaction version
- addedd `setVersion` method to transaction builder so anyoner using the library can override the default version when they build a transaction

### Other

All tests pass.

Example txs: [one](https://dexplorer.solar.org/transactions/d47ae1a16c27358351f7a52853c92c6d1c83d0f241a9155a0a469c11b97537c3), [two](https://dexplorer.solar.org/transactions/38d20222eb9c34c5869419597d4dc2583d79a0e724e4087f0b561320433538a4), [three](https://dexplorer.solar.org/transactions/75646a3c11cbc73fa670c57883ccec2889452ee9a88979aaa7dac65c740af10e)