### PR TITLE
fix: use solar addresses, add address verification, fix vendorField deserialization,  remove vendorFieldHex, use solar fixtures

### DIFF
--- a/crypto/configuration/network.py
+++ b/crypto/configuration/network.py
@@ -28,6 +28,11 @@ def get_network():
     return network
 
 
+def get_network_version():
+    network = get_network()
+    return network['version']
+
+
 def set_custom_network(epoch, version, wif):
     """Set custom network
 

--- a/crypto/exceptions.py
+++ b/crypto/exceptions.py
@@ -6,5 +6,9 @@ class SolarSerializerException(SolarCryptoException):
     """Raised when there's a serializer related issue"""
 
 
+class SolarDeserializerException(SolarCryptoException):
+    """Raised when there's a deserializer related issue"""
+
+
 class SolarInvalidTransaction(SolarCryptoException):
     """Raised when transaction is not valid"""

--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -128,3 +128,6 @@ class BaseTransactionBuilder(object):
 
     def set_version(self, version):
         self.transaction.version = version
+
+    def set_vendor_field(self, value):
+        self.transaction.vendorField = value if isinstance(value, bytes) else value.encode()

--- a/crypto/transactions/builder/htlc_lock.py
+++ b/crypto/transactions/builder/htlc_lock.py
@@ -1,4 +1,5 @@
 from crypto.constants import TRANSACTION_HTLC_LOCK, TRANSACTION_TYPE_GROUP
+from crypto.identity import address
 from crypto.transactions.builder.base import BaseTransactionBuilder
 
 
@@ -19,6 +20,10 @@ class HtlcLock(BaseTransactionBuilder):
             fee (int, optional): fee used for the transaction (default is already set)
         """
         super().__init__()
+
+        if not address.validate_address(recipient_id):
+            raise ValueError("Invalid recipient address")
+
 
         self.transaction.recipientId = recipient_id
         

--- a/crypto/transactions/builder/multi_payment.py
+++ b/crypto/transactions/builder/multi_payment.py
@@ -1,4 +1,5 @@
 from crypto.constants import TRANSACTION_MULTI_PAYMENT, TRANSACTION_TYPE_GROUP
+from crypto.identity import address
 from crypto.transactions.builder.base import BaseTransactionBuilder
 
 
@@ -28,4 +29,7 @@ class MultiPayment(BaseTransactionBuilder):
         return TRANSACTION_TYPE_GROUP.CORE.value
 
     def add_payment(self, amount, recipient_id):
+        if not address.validate_address(recipient_id):
+            raise ValueError("Invalid recipient address")
+
         self.transaction.asset['payments'].append({'amount': amount, 'recipientId': recipient_id})

--- a/crypto/transactions/builder/transfer.py
+++ b/crypto/transactions/builder/transfer.py
@@ -1,4 +1,5 @@
 from crypto.constants import TRANSACTION_TRANSFER
+from crypto.identity import address
 from crypto.transactions.builder.base import BaseTransactionBuilder
 
 
@@ -16,6 +17,9 @@ class Transfer(BaseTransactionBuilder):
             fee (int, optional): fee used for the transaction (default is already set)
         """
         super().__init__()
+
+        if not address.validate_address(recipientId):
+            raise ValueError("Invalid recipient address")
 
         self.transaction.recipientId = recipientId
 

--- a/crypto/transactions/deserializer.py
+++ b/crypto/transactions/deserializer.py
@@ -42,7 +42,7 @@ class Deserializer(object):
         if vendor_field_length > 0:
             vendor_field_offset = 59
             vendorField_take = vendor_field_offset + vendor_field_length
-            transaction.vendorField = self.serialized[vendor_field_offset:vendorField_take]
+            transaction.vendorField = self.serialized[vendor_field_offset:vendorField_take].decode()
 
         asset_offset = (58 + 1) * 2 + vendor_field_length * 2
         handled_transaction = self._handle_transaction_type(asset_offset, transaction)

--- a/crypto/transactions/deserializers/htlc_lock.py
+++ b/crypto/transactions/deserializers/htlc_lock.py
@@ -15,9 +15,7 @@ class HtlcLockDeserializer(BaseDeserializer):
         self.transaction.amount = read_bit64(self.serialized, offset=starting_position)
 
         secret_hash = hexlify(self.serialized)[(starting_position + 8) * 2:(starting_position + 8 + 32) * 2]
-
         expiration_type = read_bit8(self.serialized, offset=99)
-
         expiration_value = read_bit32(self.serialized, offset=100)
 
         recipient_start_index = (starting_position + 45) * 2

--- a/crypto/transactions/serializer.py
+++ b/crypto/transactions/serializer.py
@@ -38,17 +38,14 @@ class Serializer(object):
 
         bytes_data += write_high(self.transaction.get('senderPublicKey'))
         bytes_data += write_bit64(self.transaction.get('fee'))
-
+        
         if self.transaction.get('vendorField'):
             vendorFieldLength = len(self.transaction.get('vendorField'))
             bytes_data += write_bit8(vendorFieldLength)
             bytes_data += self.transaction['vendorField'].encode()
-        elif self.transaction.get('vendorFieldHex'):
-            vendorField_hex_length = len(self.transaction['vendorFieldHex'])
-            bytes_data += write_bit8(vendorField_hex_length / 2)
-            bytes_data += self.transaction['vendorFieldHex']
         else:
             bytes_data += write_bit8(0x00)
+
         bytes_data = self._handle_transaction_type(bytes_data)
         bytes_data = self._handle_signature(bytes_data, skip_signature, skip_second_signature, skip_multi_signature)
 

--- a/crypto/transactions/serializers/htlc_lock.py
+++ b/crypto/transactions/serializers/htlc_lock.py
@@ -4,6 +4,8 @@ from base58 import b58decode_check
 
 from binary.hex.writer import write_high
 from binary.unsigned_integer.writer import write_bit8, write_bit32, write_bit64
+from crypto.exceptions import SolarSerializerException
+from crypto.identity import address
 
 from crypto.transactions.serializers.base import BaseSerializer
 
@@ -13,6 +15,9 @@ class HtlcLockSerializer(BaseSerializer):
     """
 
     def serialize(self):
+        if not address.validate_address(self.transaction['recipientId']):
+            raise SolarSerializerException("Invalid recipient address")
+
         self.bytes_data += write_bit64(self.transaction['amount'])
         self.bytes_data += unhexlify(self.transaction['asset']['lock']['secretHash'].encode())
         self.bytes_data += write_bit8(self.transaction['asset']['lock']['expiration']['type'])

--- a/crypto/transactions/serializers/multi_payment.py
+++ b/crypto/transactions/serializers/multi_payment.py
@@ -4,6 +4,8 @@ from base58 import b58decode_check
 
 from binary.hex.writer import write_high
 from binary.unsigned_integer.writer import write_bit16, write_bit64
+from crypto.exceptions import SolarSerializerException
+from crypto.identity import address
 
 from crypto.transactions.serializers.base import BaseSerializer
 
@@ -16,6 +18,9 @@ class MultiPaymentSerializer(BaseSerializer):
         self.bytes_data += write_bit16(len(self.transaction['asset']['payments']))
 
         for payment in self.transaction['asset']['payments']:
+            if not address.validate_address(payment['recipientId']):
+                raise SolarSerializerException("Invalid recipient address")
+
             self.bytes_data += write_bit64(payment['amount'])
             recipientId = hexlify(b58decode_check(payment['recipientId']))
             self.bytes_data += write_high(recipientId)

--- a/crypto/transactions/serializers/transfer.py
+++ b/crypto/transactions/serializers/transfer.py
@@ -4,6 +4,8 @@ from base58 import b58decode_check
 
 from binary.hex.writer import write_high
 from binary.unsigned_integer.writer import write_bit32, write_bit64
+from crypto.exceptions import SolarSerializerException
+from crypto.identity import address
 
 from crypto.transactions.serializers.base import BaseSerializer
 
@@ -13,6 +15,9 @@ class TransferSerializer(BaseSerializer):
     """
 
     def serialize(self):
+        if not address.validate_address(self.transaction['recipientId']):
+            raise SolarSerializerException("Invalid recipient address")
+
         self.bytes_data += write_bit64(self.transaction['amount'])
         self.bytes_data += write_bit32(self.transaction.get('expiration', 0))
         recipientId = hexlify(b58decode_check(self.transaction['recipientId']))

--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -31,7 +31,6 @@ TRANSACTION_ATTRIBUTES = {
     'type': None,
     'typeGroup': None,
     'vendorField': None,
-    # 'vendorFieldHex': None,
     'version': None,
     'lockTransactionId': None,
     'lockSecret': None,

--- a/crypto/transactions/transaction.py
+++ b/crypto/transactions/transaction.py
@@ -1,17 +1,16 @@
 import json
 from binascii import unhexlify
 from hashlib import sha256
-from btclib.ecc import ssa
 
 from binary.hex.writer import write_high
 from binary.unsigned_integer.writer import write_bit8
+from crypto.configuration.network import get_network_version
 
 from crypto.constants import (
     TRANSACTION_DELEGATE_REGISTRATION, TRANSACTION_MULTI_SIGNATURE_REGISTRATION,
     TRANSACTION_SECOND_SIGNATURE_REGISTRATION, TRANSACTION_VOTE
 )
 from crypto.exceptions import SolarInvalidTransaction
-from crypto.schnorr import schnorr
 from crypto.transactions.deserializer import Deserializer
 from crypto.transactions.serializer import Serializer
 from crypto.utils.crypto import verify_schnorr, verify_schnorr_legacy
@@ -32,11 +31,12 @@ TRANSACTION_ATTRIBUTES = {
     'type': None,
     'typeGroup': None,
     'vendorField': None,
-    'vendorFieldHex': None,
+    # 'vendorFieldHex': None,
     'version': None,
     'lockTransactionId': None,
     'lockSecret': None,
-    'expiration': None
+    'expiration': None,
+    'network': get_network_version,
 }
 
 
@@ -88,10 +88,12 @@ class Transaction(object):
         Returns:
             bytes: bytes representation of the transaction
         """
-        return Serializer(self.to_dict()).serialize(skip_signature=skip_signature,
-                                                    skip_second_signature=skip_second_signature,
-                                                    skip_multi_signature=skip_multi_signature,
-                                                    raw=True)
+        return Serializer(self.to_dict()).serialize(
+            skip_signature=skip_signature,
+            skip_second_signature=skip_second_signature,
+            skip_multi_signature=skip_multi_signature,
+            raw=True,
+        )
 
     def parse_signatures(self, serialized, start_offset):
         """Parse the signature, second signature and multi signatures

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,20 +6,21 @@ def transaction_type_0():
     """Transaction of type "transfer"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 0,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 10000000,
         'amount': 200000000,
-        'expiration': 0,
-        'recipientId': 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
-        'signature': '136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b',  # noqa
-        'id': '129517023bd895b682bbb38b1d1f99e9222bd487899c843da22d8572b0fb52a8',
-        'serialized': 'ff02170100000000000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b0000000000000000170995750207ecaf0ccf251c1265b92ad84f553662136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b'  # noqa
+        'asset': {},
+        'fee': 10000000,
+        'id': 'c868363929575b00d58846c55139143ada15fec07c917d7139b8a422874adaf0',
+        'recipientId': 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
+        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+        'signature': '20b4091da824dc1b630ec7a09f39fe491cb2ac39dabdbe67d48753a43e8dc8cd4f76eb4ff717efbb06889882aa99a07db7bf35de3b8d5f1ad74b8284e0a68420',
+        'nonce': 1,
+        'type': 0,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000000000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b00000000000000001e0995750207ecaf0ccf251c1265b92ad84f55366220b4091da824dc1b630ec7a09f39fe491cb2ac39dabdbe67d48753a43e8dc8cd4f76eb4ff717efbb06889882aa99a07db7bf35de3b8d5f1ad74b8284e0a68420',
+        'network': 30,
     }
+
     return data
 
 
@@ -28,22 +29,22 @@ def transaction_type_1():
     """Transaction of type "second signature registration"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 1,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 500000000,
+        'amount': 0,
         'asset': {
             'signature': {
-                'publicKey': '03699e966b2525f9088a6941d8d94f7869964a000efe65783d78ac82e1199fe609'
+                'publicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
             }
         },
-        'signature': 'f9a1e2244c8318e8be85482fc02659e5c1775d246d73d5d0699ae4a1d5e3a3e84f9dcf68ee015f943d2a82eb829f35abd7901279761d96f6b43431520e955c67',  # noqa
-        'amount': 0,
-        'id': '173a3230159b45d772b2e0348f42af53913bf3e376397f29b8e0bda290badbe4',
-        'serialized': 'ff02170100000001000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1920065cd1d000000000003699e966b2525f9088a6941d8d94f7869964a000efe65783d78ac82e1199fe609f9a1e2244c8318e8be85482fc02659e5c1775d246d73d5d0699ae4a1d5e3a3e84f9dcf68ee015f943d2a82eb829f35abd7901279761d96f6b43431520e955c67'  # noqa
+        'fee': 500000000,
+        'id': 'd6185acbd8ecae7781036e5a56f9b6e2e1b4ceda218aacfd514aeaf7e8b25b1e',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': '4dea6c361e3a95fdbf939b998cac021780206faa283d4c0d3ce203bc04dffb38c427894b543f7148673c9d9c8ba936fe774b709314e4ab77b393c5befd7ab6e8',
+        'nonce': 1,
+        'type': 1,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000001000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c0065cd1d0000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1924dea6c361e3a95fdbf939b998cac021780206faa283d4c0d3ce203bc04dffb38c427894b543f7148673c9d9c8ba936fe774b709314e4ab77b393c5befd7ab6e8'
     }
     return data
 
@@ -53,23 +54,42 @@ def transaction_type_2():
     """Transaction of type "delegate registration"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 2,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 2500000000,
+        'amount': 0,
         'asset': {
             'delegate': {
-                'username': 'boldninja'
+                'username': 'mr.delegate',
+                'publicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'
             }
         },
-        'signature': 'eaf4b4dfd7903c32cf6c145ddf0744e86536719f5790b4286b08f1a10f0ad183bc601efc8a49a2a7b41758601a1793693afa1781cf0a63a8f72b08d5a1aaba1e',  # noqa
-        'amount': 0,
-        'id': 'cfd113d8cd9fd46b07030c14fac38c1d3fc0eca991e999eab9d0152ea96ab0dc',
-        'serialized': 'ff02170100000002000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19200f90295000000000009626f6c646e696e6a61eaf4b4dfd7903c32cf6c145ddf0744e86536719f5790b4286b08f1a10f0ad183bc601efc8a49a2a7b41758601a1793693afa1781cf0a63a8f72b08d5a1aaba1e'  # noqa
+        'fee': 2500000000,
+        'id': 'ac34ed8e2608d08d596e60a4627cf45859a72ec573564d8dca5e67aef213e0b9',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': '20a80c34e5fde614b32e5f2c4edac2e1dda84eced2020162b9795aa1d3c323226f62034fd7e494f4b11b1e1045d9928bd5db3436c85b26decd49d101bea7aca1',
+        'nonce': 1,
+        'type': 2,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000002000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c00f9029500000000000b6d722e64656c656761746520a80c34e5fde614b32e5f2c4edac2e1dda84eced2020162b9795aa1d3c323226f62034fd7e494f4b11b1e1045d9928bd5db3436c85b26decd49d101bea7aca1'
     }
+    # data = {
+    #     'version': 2,
+    #     'network': 30,
+    #     'typeGroup': 1,
+    #     'type': 2,
+    #     'nonce': 1,
+    #     'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
+    #     'fee': 2500000000,
+    #     'asset': {
+    #         'delegate': {
+    #             'username': 'boldninja'
+    #         }
+    #     },
+    #     'signature': 'eaf4b4dfd7903c32cf6c145ddf0744e86536719f5790b4286b08f1a10f0ad183bc601efc8a49a2a7b41758601a1793693afa1781cf0a63a8f72b08d5a1aaba1e',  # noqa
+    #     'amount': 0,
+    #     'id': 'cfd113d8cd9fd46b07030c14fac38c1d3fc0eca991e999eab9d0152ea96ab0dc',
+    #     'serialized': 'ff02170100000002000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19200f90295000000000009626f6c646e696e6a61eaf4b4dfd7903c32cf6c145ddf0744e86536719f5790b4286b08f1a10f0ad183bc601efc8a49a2a7b41758601a1793693afa1781cf0a63a8f72b08d5a1aaba1e'  # noqa
+    # }
     return data
 
 
@@ -78,20 +98,21 @@ def transaction_type_3():
     """Transaction of type "vote"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 3,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 100000000,
-        'asset': {
-            'votes': ['+022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d']
-        },
-        'signature': '86007f8e6a982bc271ec063c20f158734f0bc1e23e0e1abf9edeaa208b4810fa1d466171bba79a5c00b0a4c698728f68aa0748d98613cac247c014ee84a6fc41',  # noqa
         'amount': 0,
-        'id': '2c5d71028607674411c8e37e316a015eccbeb9ba486fddfbd393dc421540a90a',
-        'serialized': 'ff02170100000003000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19200e1f50500000000000101022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d86007f8e6a982bc271ec063c20f158734f0bc1e23e0e1abf9edeaa208b4810fa1d466171bba79a5c00b0a4c698728f68aa0748d98613cac247c014ee84a6fc41'  # noqa
+        'asset': {
+            'votes': ['+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192']
+        },
+        'fee': 100000000,
+        'id': '66339c0b613c4cd4237e8f3dfeacb6f1a1b01f5677564d36bd2adbd775ac0c5c',
+        'network': 30,
+        'recipientId': 'DNSBvFTJtQpS4hJfLerEjSXDrBT7K6HL2o',
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': '65a25eb5a49f0f6b1188007be3104e856ff42ae908b56ebb018d5d9348bf52532632e5efd04dfe383520acd34f8da0e4cd2caabe2434bfac012d5708ace7ef0a',
+        'nonce': 1,
+        'type': 3,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000003000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c00e1f50500000000000101034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19265a25eb5a49f0f6b1188007be3104e856ff42ae908b56ebb018d5d9348bf52532632e5efd04dfe383520acd34f8da0e4cd2caabe2434bfac012d5708ace7ef0a'
     }
     return data
 
@@ -101,32 +122,24 @@ def transaction_type_4():
     """Transaction of type "multi signature registration"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 4,
-        'nonce': 1,
-        'senderPublicKey': '0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896',
-        'id': 'c868aad20165a336c35e324378f0c12008d18af4c1025291efcb7539c7c917f0',
         'amount': 0,
-        'fee': 2000000000,
-        'signature': 'f5e9859c955bf8917b308ea21c88daf58661686c2017e476dcf735ad7f00aebf8e6effda3fe99e5f33f6007db7db9c9155796d9b5d31c53bd6156364a6a765d0',  # noqa
         'asset': {
             'multiSignature': {
-                'publicKeys': [
-                    '0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896',
-                    '03df0a1eb42d99b5de395cead145ba1ec2ea837be308c7ce3a4e8018b7efc7fdb8',
-                    '03860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f'
-                ],
                 'min': 2,
+                'publicKeys': ['0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896', '03df0a1eb42d99b5de395cead145ba1ec2ea837be308c7ce3a4e8018b7efc7fdb8', '03860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f']
             }
         },
-        'signatures': [
-            '0064900cb2cc3db6ca9c7e3bd363b322cdc4a39e051f655e9867935e1bb856b6dcce52845c031c690808f40340bc827bbaacd7b04bceff866cb0d386ab84715174',  # noqa
-            '01dd363ccc101a958bded1a5db1c08f13283fc7cee53da93dfe00785eb406512467ff8e445f8ad843744ac4179f30f942645dfd5bdf5f2bfc344ad02393053880a',  # noqa
-            '02d0012f035dc3fd54173c83d40217914653488fe9ce592dca34234163181d255281f2be7033725cfc4a6786509e7fabbaf0be8cf50882fc7b66fe94f259fd004e'  # noqa
-        ],
-        'serialized': 'ff021701000000040001000000000000000205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b89600943577000000000002030205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b89603df0a1eb42d99b5de395cead145ba1ec2ea837be308c7ce3a4e8018b7efc7fdb803860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17ff5e9859c955bf8917b308ea21c88daf58661686c2017e476dcf735ad7f00aebf8e6effda3fe99e5f33f6007db7db9c9155796d9b5d31c53bd6156364a6a765d00064900cb2cc3db6ca9c7e3bd363b322cdc4a39e051f655e9867935e1bb856b6dcce52845c031c690808f40340bc827bbaacd7b04bceff866cb0d386ab8471517401dd363ccc101a958bded1a5db1c08f13283fc7cee53da93dfe00785eb406512467ff8e445f8ad843744ac4179f30f942645dfd5bdf5f2bfc344ad02393053880a02d0012f035dc3fd54173c83d40217914653488fe9ce592dca34234163181d255281f2be7033725cfc4a6786509e7fabbaf0be8cf50882fc7b66fe94f259fd004e'  # noqa
+        'fee': 2000000000,
+        'id': 'c6e132e124bdcc18291079308a1d1ced1c4673b31008c4b9e537774677349580',
+        'network': 30,
+        'senderPublicKey': '0205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b896',
+        'signature': '84923dedf02195689feb29b688670f45f8694ee4cb5683b7d1b78bd7ec04761960ebac6ee3fa65611b6e3832df5e7269b3adbaaaa4fc77c9bb6ac3919110212b',
+        'signatures': ['00feaf616793db83eb7108d01a77e029428fc754d62f576d2ca205f6be846692bae1457c1cd7bd3914b4c9c9fac94e5f3028e106e4a4143acb189558616a9f5191', '017691248d193e34193213bacc5fd322ae6006d35d824aa7b3a4643eb3d1ed29f2562fab314b6955cd88fd65ef659252f161d6eeb97c4df28522d3a4010a7b10f2', '02c2ab966eb816a7ee0995c01f64c42fa0b886967cf371d954d5feb72e079fa240982d2a0f3e899b09836360caa4a2c5c31933024658b5e895fbdeec8e06f668df'],
+        'nonce': 1,
+        'type': 4,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e01000000040001000000000000000205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b89600943577000000000002030205d9bbe71c343ac9a6a83a4344fd404c3534fc7349827097d0835d160bc2b89603df0a1eb42d99b5de395cead145ba1ec2ea837be308c7ce3a4e8018b7efc7fdb803860d76b1df09659ac282cea3da5bd84fc45729f348a4a8e5f802186be72dc17f84923dedf02195689feb29b688670f45f8694ee4cb5683b7d1b78bd7ec04761960ebac6ee3fa65611b6e3832df5e7269b3adbaaaa4fc77c9bb6ac3919110212b00feaf616793db83eb7108d01a77e029428fc754d62f576d2ca205f6be846692bae1457c1cd7bd3914b4c9c9fac94e5f3028e106e4a4143acb189558616a9f5191017691248d193e34193213bacc5fd322ae6006d35d824aa7b3a4643eb3d1ed29f2562fab314b6955cd88fd65ef659252f161d6eeb97c4df28522d3a4010a7b10f202c2ab966eb816a7ee0995c01f64c42fa0b886967cf371d954d5feb72e079fa240982d2a0f3e899b09836360caa4a2c5c31933024658b5e895fbdeec8e06f668df'
     }
     return data
 
@@ -136,20 +149,20 @@ def transaction_type_5():
     """Transaction of type "ipfs"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 5,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 500000000,
         'amount': 0,
         'asset': {
-            'ipfs': 'QmR45FmbVVrixReBwJkhEKde2qwHYaQzGxu4ZoDeswuF9w'
+            'ipfs': b'Cn8eVZg'
         },
-        'signature': '0b6e81b123de99e953d3073a8760d3213ab5f5cf512e65a2dd73aebb410966d8fbc59e775deb4f23c51be0847402b5e1d4ee68732b3e6d8e8914d259d7e373eb',
-        'id': '818228ce634b46c488f3b2df8fd02bd50331ebdedb44df5b9b11b97b01e9fb36',
-        'serialized': 'ff02170100000005000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1920065cd1d000000000012202853f0f11ab91d73b73a2a86606103f45dd469ad2e89ec6f9a25febe8758d3fe0b6e81b123de99e953d3073a8760d3213ab5f5cf512e65a2dd73aebb410966d8fbc59e775deb4f23c51be0847402b5e1d4ee68732b3e6d8e8914d259d7e373eb'
+        'fee': 500000000,
+        'id': '96619bf765c72f38bee56d55c06270b4b361413ced10dac36ca934aa687c108c',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': 'f5749a4845fa89c62189c6e4958f205e9371be7ca04aa07b8e61bd25924dd8c0ee9885181bb7c55e4b110fb26ecd833b1a0d866f5c82e333d5499f4141ff4d39',
+        'nonce': 1,
+        'type': 5,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000005000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c0065cd1d000000000068656c6c6ff5749a4845fa89c62189c6e4958f205e9371be7ca04aa07b8e61bd25924dd8c0ee9885181bb7c55e4b110fb26ecd833b1a0d866f5c82e333d5499f4141ff4d39'
     }
     return data
 
@@ -159,29 +172,26 @@ def transaction_type_6():
     """Transaction of type "multi payment"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 6,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 10000000,
         'amount': 0,
         'asset': {
-            'payments': [
-                {
-                    'amount': 1,
-                    'recipientId': 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri'
-                },
-                {
-                    'amount': 2,
-                    'recipientId': 'AZFEPTWnn2Sn8wDZgCRF8ohwKkrmk2AZi1'
-                },
-            ],
+            'payments': [{
+                'amount': 1,
+                'recipientId': 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
+            }, {
+                'amount': 2,
+                'recipientId': 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4'
+            }]
         },
-        'signature': '672e89e66a9c5d7d95c21ccd07a89a111f02823146c06f14689d2cf1efd645fb648258fcf2280486d2cae19f391796d72145d2a8e6f261e887e34cd1998bdb65',
-        'id': 'e8c7293d428048f8678dc6c88cb8b32bd49c8ae9b02018297c1889d9bd33ba8d',
-        'serialized': 'ff02170100000006000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1928096980000000000000200010000000000000017134b5be4b327ddf9c2bb47fec8a1a44189e90f74020000000000000017bfa6aec83cf1bd03a0cab9f35c85ff51a3e9f041672e89e66a9c5d7d95c21ccd07a89a111f02823146c06f14689d2cf1efd645fb648258fcf2280486d2cae19f391796d72145d2a8e6f261e887e34cd1998bdb65'
+        'fee': 10000000,
+        'id': '8f148f2fdda47fde762edb24a37929d59af7906b7c455094266a5ed75dffba50',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': '4b09083a78f12d54b3b320b5793de8fafca95927ff368a6102e78bca87645efee92ca076c72062727e05f2e5033ad4980251894a696925588ff4a90665a6b231',
+        'nonce': 1,
+        'type': 6,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000006000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c809698000000000000020001000000000000001e65266cddfeec4b27a292a95d06f3d45bf9f3f61502000000000000001ed90798e15fd33f001b7c6c587dc78ae0c7d67d8c4b09083a78f12d54b3b320b5793de8fafca95927ff368a6102e78bca87645efee92ca076c72062727e05f2e5033ad4980251894a696925588ff4a90665a6b231'
     }
     return data
 
@@ -191,17 +201,23 @@ def transaction_type_7():
     """Transaction of type "delegate resignation"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 7,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 2500000000,
         'amount': 0,
-        'signature': 'bdc048ca7eb5688cc01921aecf5914118cfc78eacc23825efa6d75094a683127cc02512dc59e1e0631fa8956f482eabc54933d23011a8337ea9cab99abed504d',
-        'id': '707b4deb339e717dfef44c40db0692015ce9bbab015c007b016b8a46b341e859',
-        'serialized': 'ff02170100000007000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19200f902950000000000bdc048ca7eb5688cc01921aecf5914118cfc78eacc23825efa6d75094a683127cc02512dc59e1e0631fa8956f482eabc54933d23011a8337ea9cab99abed504d'
+        'asset': {
+            'delegate': {
+                'username': 'mr.delegate',
+                'publicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'
+            }
+        },
+        'fee': 2500000000,
+        'id': '9ef3a1f29fc801388fa9bc94f8978fb6a2a3daf7196b653d8a1f1cfe054535bd',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': '6cb1b992ab627a169b5878126939cc6df1698560247c9a07cd78e1695bbe5dd86c9d3935b2028964d716006f7d602e1c4d7881704af2448cf63445fae12d5994',
+        'nonce': 1,
+        'type': 2,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e0100000002000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c00f9029500000000000b6d722e64656c65676174656cb1b992ab627a169b5878126939cc6df1698560247c9a07cd78e1695bbe5dd86c9d3935b2028964d716006f7d602e1c4d7881704af2448cf63445fae12d5994'
     }
     return data
 
@@ -211,28 +227,27 @@ def transaction_type_8():
     """Transaction of type "HTLC lock"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 8,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 10000000,
         'amount': 200000000,
-        'recipientId': 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
         'asset': {
             'lock': {
-                'secretHash': '9c1a3815d49e0c9f78b872bfb017e825ea2db708158b70815526a830c85912b4',
+                'secretHash': '1691053581dd80959b68ec8941898837790a43ec883bb32a2a9ea10edbb57c24',
                 'expiration': {
                     'type': 1,
                     'value': 1573455822
                 }
-            },
+            }
         },
-        'signature': '7fe939b22a1da166b6ea58e3964651236fb4e0739f9716dedf92986f37df71ea7993e9a97b4a1686c0ad08028dcae08b7cb4a54b8a4db57e72b839a611e86358',
-        'id': 'e1b34afa54bbf34de5c00716b92246c5248c2135221ece169db877ca60a14007',
-        'serialized': 'ff02170100000008000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b000000009c1a3815d49e0c9f78b872bfb017e825ea2db708158b70815526a830c85912b401ce07c95d170995750207ecaf0ccf251c1265b92ad84f5536627fe939b22a1da166b6ea58e3964651236fb4e0739f9716dedf92986f37df71ea7993e9a97b4a1686c0ad08028dcae08b7cb4a54b8a4db57e72b839a611e86358'
-
+        'fee': 10000000,
+        'id': '61c27654fba0cabdb7ba38ccf2c1dffe136f605572f465d9ec14d5001875ad65',
+        'network': 30,
+        'recipientId': 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+        'senderPublicKey': '0201cd64fbf55b9de92471c9eb123eeedd9850ebed8fa6703df3af7a6b38631a2f',
+        'signature': '6a35d659c7965d009254847cebf0d7b34a652a7e8599443e72ba414dd056864b95d05b55d0834dd859a0b1cc3eeee916b7938273fc2984bf9f813c5cf03a93f9',
+        'nonce': 1,
+        'type': 8,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e01000000080001000000000000000201cd64fbf55b9de92471c9eb123eeedd9850ebed8fa6703df3af7a6b38631a2f80969800000000000000c2eb0b000000001691053581dd80959b68ec8941898837790a43ec883bb32a2a9ea10edbb57c2401ce07c95d1e65266cddfeec4b27a292a95d06f3d45bf9f3f6156a35d659c7965d009254847cebf0d7b34a652a7e8599443e72ba414dd056864b95d05b55d0834dd859a0b1cc3eeee916b7938273fc2984bf9f813c5cf03a93f9',
     }
     return data
 
@@ -245,18 +260,19 @@ def transaction_type_9():
         'asset': {
             'claim': {
                 'lockTransactionId': '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4',
-                'unlockSecret': 'c27f1ce845d8c29eebc9006be932b604fd06755521b1a8b0be4204c65377151a'
+                'unlockSecret': '6434323233626639336532303235303561366135303134323161383864396661'
             }
         },
         'fee': 0,
-        'id': 'aad3fdb321e2543af1dd9d2d4d155473a8b49cacbc116fa1f3f1b95154b336d5',
+        'id': 'b2fa958105341c02aec73b607075e446bffa7e0c7f8de12cec3bf26b520222a4',
+        'network': 30,
         'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
-        'signature': 'dcd867411d20c7aa891e44cd92e916ea1d1e64ef1518dfcdfa227e4415d846a66c60718dc9d4bfc354afa69c2f8fa6e68f57e6eaf53c51b7a209ead5702ffd71',
+        'signature': 'ea298e4e68946caa1aaee12b566b5a9843bb0b91e97ddf16440fb360aeb4b293eb86e64a5ec1d37a64ca770c6806b1712f762d093b107bda7922ede6e26cbbb1',
         'nonce': 1,
         'type': 9,
         'typeGroup': 1,
-        'version': 2,
-        'serialized': 'ff021e0100000009000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c000000000000000000943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4c27f1ce845d8c29eebc9006be932b604fd06755521b1a8b0be4204c65377151adcd867411d20c7aa891e44cd92e916ea1d1e64ef1518dfcdfa227e4415d846a66c60718dc9d4bfc354afa69c2f8fa6e68f57e6eaf53c51b7a209ead5702ffd71',
+        'version': 3,
+        'serialized': 'ff031e0100000009000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c000000000000000000943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb46434323233626639336532303235303561366135303134323161383864396661ea298e4e68946caa1aaee12b566b5a9843bb0b91e97ddf16440fb360aeb4b293eb86e64a5ec1d37a64ca770c6806b1712f762d093b107bda7922ede6e26cbbb1'
     }
     return data
 
@@ -265,22 +281,22 @@ def transaction_type_10():
     """Transaction of type "HTLC refund"
     """
     data = {
-        'version': 2,
-        'network': 23,
-        'typeGroup': 1,
-        'type': 10,
-        'nonce': 1,
-        'senderPublicKey': '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192',
-        'fee': 0,
         'amount': 0,
         'asset': {
             'refund': {
-                'lockTransactionId': '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4',
-            },
+                'lockTransactionId': '943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4'
+            }
         },
-        'signature': '16d9ef1dceb0cbb105a45af6bdde9439055f07197643f9e2837312463330fd02ec7b13d1242becfe333c1b8ab2ea91c0c8240390d86f0fb0f6cdc22ec6ac64f1',
-        'id': '9356aa730990a2ea8e9871ffa65800f34ef1a4bec3215d89c950e72d82a34e91',
-        'serialized': 'ff0217010000000a000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192000000000000000000943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb416d9ef1dceb0cbb105a45af6bdde9439055f07197643f9e2837312463330fd02ec7b13d1242becfe333c1b8ab2ea91c0c8240390d86f0fb0f6cdc22ec6ac64f1'
+        'fee': 0,
+        'id': '2b0149b4a31f67cd5b7afe2c968a39906fcebbc14611359a6d402b023b2cd4c7',
+        'network': 30,
+        'senderPublicKey': '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c',
+        'signature': 'a0e87b0ad0f2b31ad0b2c7e69589a2423c656f5e3a7d61ac03b73b634a404b15c6a3e7a188cabefe2b20ab1764310c7b9fb2ce8866b856642cdcc9561345494d',
+        'nonce': 1,
+        'type': 10,
+        'typeGroup': 1,
+        'version': 3,
+        'serialized': 'ff031e010000000a000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c000000000000000000943c220691e711c39c79d437ce185748a0018940e1a4144293af9d05627d2eb4a0e87b0ad0f2b31ad0b2c7e69589a2423c656f5e3a7d61ac03b73b634a404b15c6a3e7a188cabefe2b20ab1764310c7b9fb2ce8866b856642cdcc9561345494d'
     }
     return data
 

--- a/tests/transactions/builder/test_htlc_lock.py
+++ b/tests/transactions/builder/test_htlc_lock.py
@@ -15,11 +15,11 @@ def test_htlc_lock_transation_amount_not_int():
         """
         secret_hash = _generate_secret_hash()
         HtlcLock(
-          recipient_id='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
-          amount='bad amount number',
-          secret_hash=secret_hash,
-          expiration_type=1,
-          expiration_value=1573455822
+            recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+            amount='bad amount number',
+            secret_hash=secret_hash,
+            expiration_type=1,
+            expiration_value=1573455822
         )
 
 
@@ -29,7 +29,7 @@ def test_htlc_lock_transation_amount_zero():
         """
         secret_hash = _generate_secret_hash()
         HtlcLock(
-          recipient_id='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+          recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
           amount=0,
           secret_hash=secret_hash,
           expiration_type=1,
@@ -43,7 +43,7 @@ def test_htlc_lock_transation_amount_negative():
         """
         secret_hash = _generate_secret_hash()
         HtlcLock(
-          recipient_id='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+          recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
           amount=-5,
           secret_hash=secret_hash,
           expiration_type=1,
@@ -57,7 +57,7 @@ def test_htlc_lock_transaction(version):
     """
     secret_hash = _generate_secret_hash()
     transaction = HtlcLock(
-      recipient_id='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+      recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
       amount=200000000,
       secret_hash=secret_hash,
       expiration_type=1,
@@ -67,10 +67,10 @@ def test_htlc_lock_transaction(version):
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
     transaction.set_version(version)
-    transaction.sign('testing')
+    transaction.sign('this is a random passphrase')
     transaction_dict = transaction.to_dict()
 
-    assert transaction_dict['recipientId'] == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
+    assert transaction_dict['recipientId'] == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
     assert transaction_dict['amount'] == 200000000
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']
@@ -90,7 +90,7 @@ def test_htlc_lock_transaction_custom_fee(version):
     """
     secret_hash = _generate_secret_hash()
     transaction = HtlcLock(
-      recipient_id='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+      recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
       amount=200000000,
       secret_hash=secret_hash,
       expiration_type=1,
@@ -104,7 +104,7 @@ def test_htlc_lock_transaction_custom_fee(version):
     transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
-    assert transaction_dict['recipientId'] == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
+    assert transaction_dict['recipientId'] == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
     assert transaction_dict['amount'] == 200000000
     assert transaction_dict['nonce'] == 1
     assert transaction_dict['signature']

--- a/tests/transactions/builder/test_htlc_lock.py
+++ b/tests/transactions/builder/test_htlc_lock.py
@@ -29,11 +29,11 @@ def test_htlc_lock_transation_amount_zero():
         """
         secret_hash = _generate_secret_hash()
         HtlcLock(
-          recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
-          amount=0,
-          secret_hash=secret_hash,
-          expiration_type=1,
-          expiration_value=1573455822
+            recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+            amount=0,
+            secret_hash=secret_hash,
+            expiration_type=1,
+            expiration_value=1573455822
         )
 
 
@@ -43,11 +43,11 @@ def test_htlc_lock_transation_amount_negative():
         """
         secret_hash = _generate_secret_hash()
         HtlcLock(
-          recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
-          amount=-5,
-          secret_hash=secret_hash,
-          expiration_type=1,
-          expiration_value=1573455822
+            recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+            amount=-5,
+            secret_hash=secret_hash,
+            expiration_type=1,
+            expiration_value=1573455822
         )
 
 
@@ -57,11 +57,11 @@ def test_htlc_lock_transaction(version):
     """
     secret_hash = _generate_secret_hash()
     transaction = HtlcLock(
-      recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
-      amount=200000000,
-      secret_hash=secret_hash,
-      expiration_type=1,
-      expiration_value=1573455822
+        recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+        amount=200000000,
+        secret_hash=secret_hash,
+        expiration_type=1,
+        expiration_value=1573455822
     )
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
@@ -90,12 +90,12 @@ def test_htlc_lock_transaction_custom_fee(version):
     """
     secret_hash = _generate_secret_hash()
     transaction = HtlcLock(
-      recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
-      amount=200000000,
-      secret_hash=secret_hash,
-      expiration_type=1,
-      expiration_value=1573455822,
-      fee=5
+        recipient_id='DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz',
+        amount=200000000,
+        secret_hash=secret_hash,
+        expiration_type=1,
+        expiration_value=1573455822,
+        fee=5
     )
 
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)

--- a/tests/transactions/builder/test_multi_payment.py
+++ b/tests/transactions/builder/test_multi_payment.py
@@ -15,8 +15,8 @@ def test_multi_payment_transaction(version):
     transaction = MultiPayment()
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
-    transaction.add_payment(1, 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri')
-    transaction.add_payment(2, 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej')
+    transaction.add_payment(1, 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz')
+    transaction.add_payment(2, 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4')
     transaction.set_version(version)
     transaction.sign('testing')
     transaction_dict = transaction.to_dict()
@@ -27,9 +27,9 @@ def test_multi_payment_transaction(version):
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 10000000
     assert transaction_dict['asset']['payments'][0]['amount'] == 1
-    assert transaction_dict['asset']['payments'][0]['recipientId'] == 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri'
+    assert transaction_dict['asset']['payments'][0]['recipientId'] == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
     assert transaction_dict['asset']['payments'][1]['amount'] == 2
-    assert transaction_dict['asset']['payments'][1]['recipientId'] == 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej'
+    assert transaction_dict['asset']['payments'][1]['recipientId'] == 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4'
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid
 
@@ -42,8 +42,8 @@ def test_multi_payment_transaction_custom_fee(version):
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
     transaction.set_version(version)
-    transaction.add_payment(1, 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri')
-    transaction.add_payment(2, 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej')
+    transaction.add_payment(1, 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz')
+    transaction.add_payment(2, 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4')
     transaction.sign('testing')
     transaction_dict = transaction.to_dict()
 
@@ -53,8 +53,21 @@ def test_multi_payment_transaction_custom_fee(version):
     assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict['fee'] == 5
     assert transaction_dict['asset']['payments'][0]['amount'] == 1
-    assert transaction_dict['asset']['payments'][0]['recipientId'] == 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri'
+    assert transaction_dict['asset']['payments'][0]['recipientId'] == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
     assert transaction_dict['asset']['payments'][1]['amount'] == 2
-    assert transaction_dict['asset']['payments'][1]['recipientId'] == 'ATK14wxyYxbELq2b91bAfBY8Vmh9J6MDej'
+    assert transaction_dict['asset']['payments'][1]['recipientId'] == 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4'
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid
+
+
+@pytest.mark.parametrize("version", [2, 3])
+def test_multi_payment_transaction_invalid_recipient(version):
+    """Test if multi payment transaction gets built with a custom fee
+    """
+    transaction = MultiPayment(fee=5)
+    transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+    transaction.set_nonce(1)
+    transaction.set_version(version)
+    transaction.add_payment(1, 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz')
+    with pytest.raises(ValueError):
+        transaction.add_payment(2, 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC')

--- a/tests/transactions/builder/test_transfer.py
+++ b/tests/transactions/builder/test_transfer.py
@@ -15,7 +15,7 @@ def test_transfer_transaction(version):
     """Test if a transfer transaction gets built
     """
     transaction = Transfer(
-        recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+        recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
         amount=200000000,
     )
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
@@ -39,7 +39,7 @@ def test_transfer_transaction_update_amount(version):
     """Test if a transfer transaction can update an amount
     """
     transaction = Transfer(
-        recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+        recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
         amount=200000000
     )
     transaction.set_amount(10)
@@ -64,7 +64,7 @@ def test_transfer_transaction_custom_fee(version):
     """Test if a transfer transaction gets built with a custom fee
     """
     transaction = Transfer(
-        recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+        recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
         amount=200000000,
         fee=5
     )
@@ -88,7 +88,7 @@ def test_transfer_secondsig_transaction(version):
     """Test if a transfer transaction with second signature gets built
     """
     transaction = Transfer(
-        recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+        recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
         amount=200000000,
     )
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
@@ -125,7 +125,7 @@ def test_transfer_transaction_amount_not_int():
         """Test error handling in constructor for non-integer amount
         """
         Transfer(
-            recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+            recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
             amount='bad amount'
         )
 
@@ -135,6 +135,16 @@ def test_transfer_transaction_amount_zero():
         """Test error handling in constructor for non-integer amount
         """
         Transfer(
-            recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+            recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
             amount=0
+        )
+
+
+def test_transfer_transaction_invalid_address():
+    with pytest.raises(ValueError):
+        """Test error handling in constructor for non-integer amount
+        """
+        Transfer(
+            recipientId='AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC',
+            amount=100
         )

--- a/tests/transactions/builder/test_vote.py
+++ b/tests/transactions/builder/test_vote.py
@@ -32,6 +32,31 @@ def test_vote_transaction(version):
 
 
 @pytest.mark.parametrize("version", [2, 3])
+def test_vote_transaction_with_vendor_field(version):
+    """Test if a vote transaction gets built
+    """
+    vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+
+    transaction = Vote(vote)
+    transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+    transaction.set_nonce(1)
+    transaction.set_vendor_field("hello world")
+    transaction.set_version(version)
+    transaction.sign('testing')
+    transaction_dict = transaction.to_dict()
+
+    assert transaction_dict['nonce'] == 1
+    assert transaction_dict['vendorField'] == "hello world"
+    assert transaction_dict['signature']
+    assert transaction_dict['asset']['votes']
+    assert transaction_dict['type'] is TRANSACTION_VOTE
+    assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
+    assert transaction_dict['fee'] == 100000000
+
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
+
+
+@pytest.mark.parametrize("version", [2, 3])
 def test_vote_transaction_custom_fee(version):
     """Test if a vote transaction gets built with a custom fee
     """

--- a/tests/transactions/deserializers/test_htlc_lock.py
+++ b/tests/transactions/deserializers/test_htlc_lock.py
@@ -2,23 +2,23 @@ from crypto.transactions.deserializer import Deserializer
 
 
 def test_htlc_lock_deserializer():
-    serialized = 'ff02170100000008000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b000000000f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c545401ce07c95d170995750207ecaf0ccf251c1265b92ad84f5536627fe939b22a1da166b6ea58e3964651236fb4e0739f9716dedf92986f37df71ea7993e9a97b4a1686c0ad08028dcae08b7cb4a54b8a4db57e72b839a611e86358'  # noqa
+    serialized = 'ff031e01000000080001000000000000000201cd64fbf55b9de92471c9eb123eeedd9850ebed8fa6703df3af7a6b38631a2f80969800000000000000c2eb0b000000001691053581dd80959b68ec8941898837790a43ec883bb32a2a9ea10edbb57c2401ce07c95d1e65266cddfeec4b27a292a95d06f3d45bf9f3f6156a35d659c7965d009254847cebf0d7b34a652a7e8599443e72ba414dd056864b95d05b55d0834dd859a0b1cc3eeee916b7938273fc2984bf9f813c5cf03a93f9'  # noqa
 
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
 
-    assert actual.version == 2
-    assert actual.network == 23
+    assert actual.version == 3
+    assert actual.network == 30
     assert actual.typeGroup == 1
     assert actual.type == 8
     assert actual.nonce == 1
-    assert actual.senderPublicKey == '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+    assert actual.senderPublicKey == '0201cd64fbf55b9de92471c9eb123eeedd9850ebed8fa6703df3af7a6b38631a2f'
     assert actual.fee == 10000000
-    assert actual.signature == '7fe939b22a1da166b6ea58e3964651236fb4e0739f9716dedf92986f37df71ea7993e9a97b4a1686c0ad08028dcae08b7cb4a54b8a4db57e72b839a611e86358'
+    assert actual.signature == '6a35d659c7965d009254847cebf0d7b34a652a7e8599443e72ba414dd056864b95d05b55d0834dd859a0b1cc3eeee916b7938273fc2984bf9f813c5cf03a93f9'
     assert actual.amount == 200000000
-    assert actual.id == 'e1b34afa54bbf34de5c00716b92246c5248c2135221ece169db877ca60a14007'
-    assert actual.recipientId == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
-    assert actual.asset['lock']['secretHash'] == '0f128d401958b1b30ad0d10406f47f9489321017b4614e6cb993fc63913c5454'  # noqa
+    assert actual.id == '61c27654fba0cabdb7ba38ccf2c1dffe136f605572f465d9ec14d5001875ad65'
+    assert actual.recipientId == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'
+    assert actual.asset['lock']['secretHash'] == '1691053581dd80959b68ec8941898837790a43ec883bb32a2a9ea10edbb57c24'  # noqa
     assert actual.asset['lock']['expiration']['type'] == 1  # noqa
     assert actual.asset['lock']['expiration']['value'] == 1573455822  # noqa
 

--- a/tests/transactions/deserializers/test_multi_payment.py
+++ b/tests/transactions/deserializers/test_multi_payment.py
@@ -2,24 +2,24 @@ from crypto.transactions.deserializer import Deserializer
 
 
 def test_multi_payment_deserializer():
-    serialized = 'ff02170100000006000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1928096980000000000000200010000000000000017134b5be4b327ddf9c2bb47fec8a1a44189e90f74020000000000000017bfa6aec83cf1bd03a0cab9f35c85ff51a3e9f041672e89e66a9c5d7d95c21ccd07a89a111f02823146c06f14689d2cf1efd645fb648258fcf2280486d2cae19f391796d72145d2a8e6f261e887e34cd1998bdb65'  # noqa
+    serialized = 'ff031e0100000006000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c809698000000000000020001000000000000001e65266cddfeec4b27a292a95d06f3d45bf9f3f61502000000000000001ed90798e15fd33f001b7c6c587dc78ae0c7d67d8c4b09083a78f12d54b3b320b5793de8fafca95927ff368a6102e78bca87645efee92ca076c72062727e05f2e5033ad4980251894a696925588ff4a90665a6b231'  # noqa
 
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
 
-    assert actual.version == 2
-    assert actual.network == 23
+    assert actual.version == 3
+    assert actual.network == 30
     assert actual.typeGroup == 1
     assert actual.type == 6
     assert actual.nonce == 1
-    assert actual.senderPublicKey == '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+    assert actual.senderPublicKey == '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'
     assert actual.fee == 10000000
-    assert actual.signature == '672e89e66a9c5d7d95c21ccd07a89a111f02823146c06f14689d2cf1efd645fb648258fcf2280486d2cae19f391796d72145d2a8e6f261e887e34cd1998bdb65'
+    assert actual.signature == '4b09083a78f12d54b3b320b5793de8fafca95927ff368a6102e78bca87645efee92ca076c72062727e05f2e5033ad4980251894a696925588ff4a90665a6b231'
     assert actual.amount == 0
-    assert actual.id == 'e8c7293d428048f8678dc6c88cb8b32bd49c8ae9b02018297c1889d9bd33ba8d'
+    assert actual.id == '8f148f2fdda47fde762edb24a37929d59af7906b7c455094266a5ed75dffba50'
     assert actual.asset['payments'][0]['amount'] == 1  # noqa
-    assert actual.asset['payments'][0]['recipientId'] == 'AHXtmB84sTZ9Zd35h9Y1vfFvPE2Xzqj8ri'  # noqa
+    assert actual.asset['payments'][0]['recipientId'] == 'DEMvpU4Qq6KvSzF3sRNjGCkm6Kj7cFfVaz'  # noqa
     assert actual.asset['payments'][1]['amount'] == 2  # noqa
-    assert actual.asset['payments'][1]['recipientId'] == 'AZFEPTWnn2Sn8wDZgCRF8ohwKkrmk2AZi1'  # noqa
+    assert actual.asset['payments'][1]['recipientId'] == 'DQveGkK7te33dWJwHgKpGKDr5amxAE7PF4'  # noqa
 
     actual.verify()

--- a/tests/transactions/deserializers/test_transfer.py
+++ b/tests/transactions/deserializers/test_transfer.py
@@ -3,23 +3,23 @@ from crypto.transactions.deserializer import Deserializer
 
 
 def test_transfer_deserializer():
-    serialized = 'ff02170100000000000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b0000000000000000170995750207ecaf0ccf251c1265b92ad84f553662136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b'  # noqa
+    serialized = 'ff031e0100000000000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19280969800000000000000c2eb0b00000000000000001e0995750207ecaf0ccf251c1265b92ad84f55366220b4091da824dc1b630ec7a09f39fe491cb2ac39dabdbe67d48753a43e8dc8cd4f76eb4ff717efbb06889882aa99a07db7bf35de3b8d5f1ad74b8284e0a68420'  # noqa
 
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
 
-    assert actual.version == 2
-    assert actual.network == 23
+    assert actual.version == 3
+    assert actual.network == 30
     assert actual.typeGroup == 1
     assert actual.expiration == 0
     assert actual.type == 0
     assert actual.amount == 200000000
     assert actual.fee == 10000000
     assert actual.nonce == 1
-    assert actual.recipientId == 'AGeYmgbg2LgGxRW2vNNJvQ88PknEJsYizC'
+    assert actual.recipientId == 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
     assert actual.senderPublicKey == '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'  # noqa
-    assert actual.id == '129517023bd895b682bbb38b1d1f99e9222bd487899c843da22d8572b0fb52a8'
-    assert actual.signature == '136c29d921b58ae3194020b82e9808f9cd54f7178cb34678f570f28226b8e56ba0ad318297a3bacbb37ab22ddaa5dbf1901cda3ec2d2bca5ce98d6407839ab9b'
+    assert actual.id == 'c868363929575b00d58846c55139143ada15fec07c917d7139b8a422874adaf0'
+    assert actual.signature == '20b4091da824dc1b630ec7a09f39fe491cb2ac39dabdbe67d48753a43e8dc8cd4f76eb4ff717efbb06889882aa99a07db7bf35de3b8d5f1ad74b8284e0a68420'
 
     actual.verify()
 

--- a/tests/transactions/deserializers/test_vote.py
+++ b/tests/transactions/deserializers/test_vote.py
@@ -35,7 +35,7 @@ def test_vote_with_vendor_field():
     assert actual.type == 3
     assert actual.amount == 0
     assert actual.fee == 100000000
-    assert actual.vendorField == b"hello world"
+    assert actual.vendorField == "hello world"
     assert actual.nonce == 1
     assert actual.senderPublicKey == '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'  # noqa
     assert actual.id == 'c751be6c2b9525fb1b089b06c942d581a854422eb1fa9567d728c0d00b0b9e6a'

--- a/tests/transactions/deserializers/test_vote.py
+++ b/tests/transactions/deserializers/test_vote.py
@@ -2,22 +2,45 @@ from crypto.transactions.deserializer import Deserializer
 
 
 def test_vote_deserializer():
-    serialized = 'ff02170100000003000100000000000000034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed19200e1f50500000000000101022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d86007f8e6a982bc271ec063c20f158734f0bc1e23e0e1abf9edeaa208b4810fa1d466171bba79a5c00b0a4c698728f68aa0748d98613cac247c014ee84a6fc41'  # noqa
+    serialized = 'ff031e0100000003000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c00e1f50500000000000101034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192fc095c30fba364d579b87ed242e0f886cca53a5c43765a941b237eed2f306d0462a371cfce362d14f5f2ec342806a27480e1c6f60a86887268a146f0b804665a'  # noqa
 
     deserializer = Deserializer(serialized)
     actual = deserializer.deserialize()
 
-    assert actual.version == 2
-    assert actual.network == 23
+    assert actual.version == 3
+    assert actual.network == 30
     assert actual.typeGroup == 1
     assert actual.type == 3
     assert actual.amount == 0
     assert actual.fee == 100000000
     assert actual.nonce == 1
-    assert actual.senderPublicKey == '034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'  # noqa
-    assert actual.id == '2c5d71028607674411c8e37e316a015eccbeb9ba486fddfbd393dc421540a90a'
-    assert actual.signature == '86007f8e6a982bc271ec063c20f158734f0bc1e23e0e1abf9edeaa208b4810fa1d466171bba79a5c00b0a4c698728f68aa0748d98613cac247c014ee84a6fc41'
+    assert actual.senderPublicKey == '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'  # noqa
+    assert actual.id == '7223531535408b2d30ec396a66e56d27a74de829b31484763b74de799c212e79'
+    assert actual.signature == 'fc095c30fba364d579b87ed242e0f886cca53a5c43765a941b237eed2f306d0462a371cfce362d14f5f2ec342806a27480e1c6f60a86887268a146f0b804665a'
 
-    assert actual.asset['votes'] == ['+022cca9529ec97a772156c152a00aad155ee6708243e65c9d211a589cb5d43234d']  # noqa
+    assert actual.asset['votes'] == ['+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192']  # noqa
+
+    actual.verify()
+
+
+def test_vote_with_vendor_field():
+    serialized = 'ff031e0100000003000100000000000000037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c00e1f505000000000b68656c6c6f20776f726c640101034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed1928cfd3bca4512e10680be1ed4ea150773976b04797fb03792fe792f8f046da866dac7d6361e5e39bf6d88bd1cccddbaef1d4b4d2dbb38381ce4a58fa35e16b5cb'  # noqa
+
+    deserializer = Deserializer(serialized)
+    actual = deserializer.deserialize()
+
+    assert actual.version == 3
+    assert actual.network == 30
+    assert actual.typeGroup == 1
+    assert actual.type == 3
+    assert actual.amount == 0
+    assert actual.fee == 100000000
+    assert actual.vendorField == b"hello world"
+    assert actual.nonce == 1
+    assert actual.senderPublicKey == '037fde73baaa48eb75c013fe9ff52a74a096d48b9978351bdcb5b72331ca37487c'  # noqa
+    assert actual.id == 'c751be6c2b9525fb1b089b06c942d581a854422eb1fa9567d728c0d00b0b9e6a'
+    assert actual.signature == '8cfd3bca4512e10680be1ed4ea150773976b04797fb03792fe792f8f046da866dac7d6361e5e39bf6d88bd1cccddbaef1d4b4d2dbb38381ce4a58fa35e16b5cb'
+
+    assert actual.asset['votes'] == ['+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192']  # noqa
 
     actual.verify()


### PR DESCRIPTION
I'm addressing some things @sleepdefic1t has raised with me in addition to:

- adding vendor field to all transaction types
- removed vendor field hex  attribute (can't see it being used anywhere in `core`)
- fixed deserializing a vendor field value