### PR TITLE
feat: add a set_fee method to builder

### DIFF
--- a/crypto/transactions/builder/base.py
+++ b/crypto/transactions/builder/base.py
@@ -98,6 +98,9 @@ class BaseTransactionBuilder(object):
     def set_nonce(self, nonce):
         self.transaction.nonce = nonce
 
+    def set_fee(self, fee: int):
+        self.transaction.fee = fee
+
     def set_amount(self, amount):
         self.transaction.amount = amount
 

--- a/tests/transactions/builder/test_multi_payment.py
+++ b/tests/transactions/builder/test_multi_payment.py
@@ -40,8 +40,9 @@ def test_multi_payment_transaction(version):
 
 
 @pytest.mark.parametrize("version", [2, 3])
-def test_multi_payment_transaction_custom_fee(version):
-    """Test if multi payment transaction gets built with a custom fee"""
+def test_multi_payment_transaction_custom_fee_via_kwargs(version):
+    """Test if multi payment transaction gets built with a custom fee
+    """
     transaction = MultiPayment(fee=5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
     transaction.set_nonce(1)
@@ -66,5 +67,32 @@ def test_multi_payment_transaction_custom_fee(version):
         transaction_dict["asset"]["payments"][1]["recipientId"]
         == "DNSBvFTJtQpS4hJfLerEjSXDrBT7K6HL2o"
     )
+
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
+
+
+@pytest.mark.parametrize("version", [2, 3])
+def test_multi_payment_transaction_custom_fee_via_method(version):
+    """Test if multi payment transaction gets built with a custom fee
+    """
+    transaction = MultiPayment()
+    transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+    transaction.set_nonce(1)
+    transaction.set_version(version)
+    transaction.set_fee(1337)
+    transaction.add_payment(1, 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib')
+    transaction.add_payment(2, 'DNSBvFTJtQpS4hJfLerEjSXDrBT7K6HL2o')
+    transaction.sign('testing')
+    transaction_dict = transaction.to_dict()
+
+    assert transaction_dict['nonce'] == 1
+    assert transaction_dict['signature']
+    assert transaction_dict['type'] is TRANSACTION_MULTI_PAYMENT
+    assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
+    assert transaction_dict['fee'] == 1337
+    assert transaction_dict['asset']['payments'][0]['amount'] == 1
+    assert transaction_dict['asset']['payments'][0]['recipientId'] == 'D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib'
+    assert transaction_dict['asset']['payments'][1]['amount'] == 2
+    assert transaction_dict['asset']['payments'][1]['recipientId'] == 'DNSBvFTJtQpS4hJfLerEjSXDrBT7K6HL2o'
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid

--- a/tests/transactions/builder/test_transfer.py
+++ b/tests/transactions/builder/test_transfer.py
@@ -80,8 +80,9 @@ def test_transfer_transaction_update_amount(version):
 
 
 @pytest.mark.parametrize("version", [2, 3])
-def test_transfer_transaction_custom_fee(version):
-    """Test if a transfer transaction gets built with a custom fee"""
+def test_transfer_transaction_custom_fee_via_kwargs(version):
+    """Test if a transfer transaction gets built with a custom fee
+    """
     transaction = Transfer(
         recipientId="D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib", amount=200000000, fee=5
     )
@@ -96,6 +97,30 @@ def test_transfer_transaction_custom_fee(version):
     assert transaction_dict["type"] is TRANSACTION_TRANSFER
     assert transaction_dict["typeGroup"] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict["fee"] == 5
+
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
+
+
+@pytest.mark.parametrize("version", [2, 3])
+def test_transfer_transaction_custom_fee_via_method(version):
+    """Test if a transfer transaction gets built with a custom fee
+    """
+    transaction = Transfer(
+        recipientId='D61mfSggzbvQgTUe6JhYKH2doHaqJ3Dyib',
+        amount=200000000,
+    )
+    transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+    transaction.set_nonce(1)
+    transaction.set_fee(1337)
+    transaction.set_version(version)
+    transaction.sign('this is a top secret passphrase')
+    transaction_dict = transaction.to_dict()
+
+    assert transaction_dict['nonce'] == 1
+    assert transaction_dict['signature']
+    assert transaction_dict['type'] is TRANSACTION_TRANSFER
+    assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
+    assert transaction_dict['fee'] == 1337
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid
 

--- a/tests/transactions/builder/test_vote.py
+++ b/tests/transactions/builder/test_vote.py
@@ -31,9 +31,10 @@ def test_vote_transaction(version):
 
 
 @pytest.mark.parametrize("version", [2, 3])
-def test_vote_transaction_custom_fee(version):
-    """Test if a vote transaction gets built with a custom fee"""
-    vote = "+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192"
+def test_vote_transaction_custom_fee_via_kwargs(version):
+    """Test if a vote transaction gets built with a custom fee
+    """
+    vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
 
     transaction = Vote(vote, 5)
     transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
@@ -48,5 +49,29 @@ def test_vote_transaction_custom_fee(version):
     assert transaction_dict["type"] is TRANSACTION_VOTE
     assert transaction_dict["typeGroup"] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict["fee"] == 5
+
+    transaction.verify()  # if no exception is raised, it means the transaction is valid
+
+
+@pytest.mark.parametrize("version", [2, 3])
+def test_vote_transaction_custom_fee_via_method(version):
+    """Test if a vote transaction gets built with a custom fee
+    """
+    vote = '+034151a3ec46b5670a682b0a63394f863587d1bc97483b1b6c70eb58e7f0aed192'
+
+    transaction = Vote(vote)
+    transaction.set_type_group(TRANSACTION_TYPE_GROUP.CORE)
+    transaction.set_nonce(1)
+    transaction.set_version(version)
+    transaction.set_fee(1337)
+    transaction.sign('testing')
+    transaction_dict = transaction.to_dict()
+
+    assert transaction_dict['nonce'] == 1
+    assert transaction_dict['signature']
+    assert transaction_dict['asset']['votes']
+    assert transaction_dict['type'] is TRANSACTION_VOTE
+    assert transaction_dict['typeGroup'] == TRANSACTION_TYPE_GROUP.CORE.value
+    assert transaction_dict['fee'] == 1337
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid


### PR DESCRIPTION
I wish to slowly deprecate the existing `fee` kwarg that is used to modify fees on a transaction by replacing it with a `set_fee` method that is available globally in all transactions via builder.