### PR TITLE
refactor: replace ripemd160 from hashlib with pycryptodome lib

### DIFF
--- a/crypto/identity/address.py
+++ b/crypto/identity/address.py
@@ -1,6 +1,8 @@
 import hashlib
 from binascii import unhexlify
 
+from Crypto.Hash import RIPEMD160
+
 from base58 import b58decode_check, b58encode_check
 from binary.unsigned_integer.writer import write_bit8
 
@@ -22,7 +24,8 @@ def address_from_public_key(public_key, network_version=None):
         network = get_network()
         network_version = network["version"]
 
-    ripemd160 = hashlib.new("ripemd160", unhexlify(public_key.encode()))
+    ripemd160 = RIPEMD160.new()
+    ripemd160.update(unhexlify(public_key))
     seed = write_bit8(network_version) + ripemd160.digest()
     return b58encode_check(seed).decode()
 
@@ -42,7 +45,8 @@ def address_from_private_key(private_key, network_version=None):
         network_version = network["version"]
 
     private_key = PrivateKey.from_hex(private_key)
-    ripemd160 = hashlib.new("ripemd160", unhexlify(private_key.public_key))
+    ripemd160 = RIPEMD160.new()
+    ripemd160.update(unhexlify(private_key.public_key))
     seed = write_bit8(network_version) + ripemd160.digest()
     return b58encode_check(seed).decode()
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import sys
 
 import setuptools
 
-requires = ["base58", "binary-helpers", "coincurve", "btclib"]
+requires = ["base58", "binary-helpers", "coincurve", "btclib", "pycryptodome"]
 
 tests_require = [
     "flake8>=4.0.1",

--- a/tests/transactions/builder/test_ipfs.py
+++ b/tests/transactions/builder/test_ipfs.py
@@ -26,7 +26,7 @@ def test_ipfs_transaction(version):
     assert transaction_dict["type"] is TRANSACTION_IPFS
     assert transaction_dict["typeGroup"] == TRANSACTION_TYPE_GROUP.CORE.value
     assert transaction_dict["fee"] == 5000000
-    assert transaction_dict["asset"]["ipfs"] == ipfs_id
+    assert transaction_dict["asset"]["ipfs"] == ipfs_cid
 
     transaction.verify()  # if no exception is raised, it means the transaction is valid
 


### PR DESCRIPTION
I've tested the package on newer Python versions and tests failed to the the built-in `hashlib` not having support for ripemd160 anymore. I've replaced it with `pycryptodome` which worked on all version that I've tested (3.6, 3.7, 3.8).