### PR TITLE
fix: support unicode characters in memo

### DIFF
--- a/solar_crypto/transactions/serializer.py
+++ b/solar_crypto/transactions/serializer.py
@@ -45,7 +45,7 @@ class Serializer(object):
         bytes_data += write_bit64(self.transaction.get("fee"))
 
         if self.transaction.get("memo"):
-            memo_length = len(self.transaction.get("memo"))
+            memo_length = len(self.transaction.get("memo").encode())
             bytes_data += write_bit8(memo_length)
             bytes_data += self.transaction["memo"].encode()
         else:


### PR DESCRIPTION
Core will reject a transfer from the current implementation if you add a unicode character like an emoji.